### PR TITLE
Fix for installing Wakhan from source

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name='wakhan',
       author='Tanveer Ahmad',
       author_email = 'tanveer.ahmad@nih.gov',
       license='MIT',
-      packages=['src', 'src.hapcorrect', 'src.hapcorrect.src'],
+      packages=['src', 'src.hapcorrect.src'],
       package_data={'src': ['annotations/*']},
       entry_points={'console_scripts': ['wakhan = src.main:main']},
       )

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name='wakhan',
       author='Tanveer Ahmad',
       author_email = 'tanveer.ahmad@nih.gov',
       license='MIT',
-      packages=['src'],
+      packages=['src', 'src.hapcorrect', 'src.hapcorrect.src'],
       package_data={'src': ['annotations/*']},
       entry_points={'console_scripts': ['wakhan = src.main:main']},
       )


### PR DESCRIPTION
When trying to install the package using `pip install .` it fails. However, adding `src.hapcorrect.src` fixes this. 
I am pretty unfamiliar with how python packages work so please confirm this is actually supposed to be specified in this way. 