### PR TITLE
Support SV VCFs from multiple callers, not just Severus

### DIFF
--- a/src/breakpoint/breakpoints.py
+++ b/src/breakpoint/breakpoints.py
@@ -46,7 +46,7 @@ def sv_vcf_bps_cn_check(path, args):
     #########################################
     _logging_level = logger.level
     logger.setLevel(logging.CRITICAL)
-    my_parser = VCFParser(infile=path, split_variants=True, check_info=True)
+    my_parser = VCFParser(infile=path, split_variants=True, check_info=False)
 
     chr_phaseblocks = defaultdict(IntervalTree)
     chr_loh = defaultdict(IntervalTree)
@@ -95,15 +95,47 @@ def sv_vcf_bps_cn_check(path, args):
     bp_junctions_single_chr = [[]]
 
     for variant in my_parser:
-        dv_value = int(variant[my_parser.individuals[0]].split(':')[4])
+        # Get supporting read count based on detected tool
+        # Severus: DV at FORMAT index 4
+        # Sniffles2: DV at FORMAT index 3
+        # Savana: no DV — use SUPPORT from INFO
+        # NanoMonSV: no DV — use TUMOR_DP from INFO
+        # Benchmark VCF: no DV — default to BP_MIN_COV to pass threshold
+        # Read DV (variant-supporting reads) by looking up its position in this
+        # record's own FORMAT column, rather than assuming a fixed index.
+        # FORMAT differs per caller:
+        #   Severus   GT:GQ:VAF:hVAF:DR:DV  -> DV at 5
+        #   Sniffles2 GT:GQ:DR:DV:PS        -> DV at 3
+        #   benchmark GT:PSL:PSO:CN:GTPG    -> no DV
+        # If the caller reports no DV, do not invent a low value: the caller
+        # already applied its own FILTER, so pass the variant through.
+        dv_value = 999
+        try:
+            fmt_fields = variant['FORMAT'].split(':')
+            if 'DV' in fmt_fields and my_parser.individuals:
+                sample_vals = variant[my_parser.individuals[0]].split(':')
+                dv_value = int(sample_vals[fmt_fields.index('DV')])
+        except (IndexError, ValueError, KeyError, AttributeError):
+            dv_value = 999
+
         if dv_value < bp_cov_threshold:
             continue
 
-        if ("INV" in variant['ID'] and variant['info_dict']['DETAILED_TYPE'] == ['reciprocal_inv']) or  "INS" in variant['ID']:
-            continue
-        if variant['info_dict']['SVTYPE'][0] == 'INV' or variant['info_dict']['SVTYPE'][0] == 'DUP' or \
-                ((variant['info_dict']['SVTYPE'][0] == 'INS' or variant['info_dict']['SVTYPE'][0] == 'DEL') and
-                        int(variant['info_dict']['SVLEN'][0]) > args.breakpoints_min_length):
+        # Skip reciprocal inversions (Severus-specific field — skip check if absent)
+        # Use SVTYPE from INFO for INS check — ID-based check only works for Severus
+        svtype_check = variant['info_dict']['SVTYPE'][0] if 'SVTYPE' in variant['info_dict'] else ''
+        if 'DETAILED_TYPE' in variant['info_dict']:
+            if ("INV" in variant['ID'] and variant['info_dict']['DETAILED_TYPE'] == ['reciprocal_inv']) or svtype_check == 'INS':
+                continue
+        else:
+            if svtype_check == 'INS':
+                continue
+        svtype = variant['info_dict']['SVTYPE'][0] if 'SVTYPE' in variant['info_dict'] else ''
+        # Use SVTYPE from INFO field (works for all tools) rather than variant ID
+        # (ID-based checks like "INS" in variant['ID'] only work for Severus-style IDs)
+        is_ins_or_del = svtype in ('INS', 'DEL') and 'SVLEN' in variant['info_dict'] and abs(int(variant['info_dict']['SVLEN'][0])) > args.breakpoints_min_length
+        is_inv_or_dup = svtype in ('INV', 'DUP')
+        if is_inv_or_dup or is_ins_or_del:
             if not variant['CHROM'] in chroms:
                 continue
 
@@ -117,10 +149,11 @@ def sv_vcf_bps_cn_check(path, args):
                 if different_hp_coverage(variant['CHROM'], start) and different_hp_coverage(variant['CHROM'], end):
                     hp = variant['info_dict']['HP'][0]
 
+            bp_junctions.append([variant['CHROM'], int(variant['POS']), int(variant['POS'])+abs(int(variant['info_dict']['SVLEN'][0]))])
             bp_junctions_bnd.append([variant['CHROM'], int(variant['POS'])])
-            bp_junctions_bnd.append([variant['CHROM'], int(variant['POS'])+int(variant['info_dict']['SVLEN'][0])])
+            bp_junctions_bnd.append([variant['CHROM'], int(variant['POS'])+abs(int(variant['info_dict']['SVLEN'][0]))])
             sample_list[variant['ID']] = bps_sample(variant['CHROM'], int(variant['POS']), variant['ID'],
-                                                    variant['CHROM'], int(variant['POS'])+int(variant['info_dict']['SVLEN'][0]), hp, dv_value, False)
+                                                    variant['CHROM'], int(variant['POS'])+abs(int(variant['info_dict']['SVLEN'][0])), hp, dv_value, False)
 
         elif variant['info_dict']['SVTYPE'][0] == 'sBND' or 'sBND' in variant['ID']:
             hp = '0|0'
@@ -135,15 +168,26 @@ def sv_vcf_bps_cn_check(path, args):
 
         elif variant['info_dict']['SVTYPE'][0] == 'BND':
 
-            s = variant['ALT']
-            for ch in ['[', ']', 'N']:
-                if ch in s:
-                    s = s.replace(ch, '')
-
+            # BND ALT looks like t[p[ or t]p] where t is the ref base(s)
+            # and p is chr:pos. Severus writes t as 'N' so the old code
+            # stripped '[', ']', 'N' to isolate p. Other callers write the
+            # real base (G/C/T/A), which then stays glued on (e.g. 'Gchr5').
+            # Split on the bracket instead so any ref base is handled.
+            alt_str = variant['ALT']
+            bracket = '[' if '[' in alt_str else (']' if ']' in alt_str else '')
+            if not bracket:
+                continue
+            alt_parts = alt_str.split(bracket)
+            if len(alt_parts) < 2:
+                continue
+            s = alt_parts[1]
             if len(s.split(':')) < 2:
                 continue
             chr2_id = s.split(':')[0]
-            chr2_end = int(s.split(':')[1])
+            try:
+                chr2_end = int(s.split(':')[1])
+            except ValueError:
+                continue
 
             if not variant['CHROM'] in chroms or not chr2_id in chroms:
                 continue

--- a/src/breakpoint/breakpoints_arcs.py
+++ b/src/breakpoint/breakpoints_arcs.py
@@ -10,7 +10,7 @@ from src.utils.chromosome import get_contigs_list, df_chromosomes_sorter
 def get_all_breakpoints_data(edges, edges_chr, height, path, args):
     _logging_level = logger.level
     logger.setLevel(logging.CRITICAL)
-    my_parser = VCFParser(infile=path, split_variants=True, check_info=True)
+    my_parser = VCFParser(infile=path, split_variants=True, check_info=False)
 
     chroms = get_contigs_list(args.contigs)
     bp_junctions_inv = [[]]
@@ -27,11 +27,11 @@ def get_all_breakpoints_data(edges, edges_chr, height, path, args):
             bp_junctions_inv.append([variant['CHROM'], int(variant['POS'])])
         elif variant['info_dict']['SVTYPE'][0] == 'sBND':
             bp_junctions_sbnd.append([variant['CHROM'], int(variant['POS'])])
-        elif (variant['info_dict']['SVTYPE'][0] == 'DUP') and int(variant['info_dict']['SVLEN'][0]) > args.breakpoints_min_length:
+        elif (variant['info_dict']['SVTYPE'][0] == 'DUP') and abs(int(variant['info_dict']['SVLEN'][0])) > args.breakpoints_min_length:
             bp_junctions_dup.append([variant['CHROM'], int(variant['POS'])])
-        elif (variant['info_dict']['SVTYPE'][0] == 'INS') and int(variant['info_dict']['SVLEN'][0]) > args.breakpoints_min_length:
+        elif (variant['info_dict']['SVTYPE'][0] == 'INS') and abs(int(variant['info_dict']['SVLEN'][0])) > args.breakpoints_min_length:
             bp_junctions_ins.append([variant['CHROM'], int(variant['POS'])])
-        elif variant['info_dict']['SVTYPE'][0] == 'DEL' and int(variant['info_dict']['SVLEN'][0]) > args.breakpoints_min_length:
+        elif variant['info_dict']['SVTYPE'][0] == 'DEL' and abs(int(variant['info_dict']['SVLEN'][0])) > args.breakpoints_min_length:
             bp_junctions_del.append([variant['CHROM'], int(variant['POS'])])
 
     logger.setLevel(_logging_level)

--- a/src/hapcorrect/main_hapcorrect.py
+++ b/src/hapcorrect/main_hapcorrect.py
@@ -67,10 +67,7 @@ def main_process(args):
     else:
         os.mkdir(args.out_dir_plots+'/data_phasing')
 
-    if os.path.exists(args.out_dir_plots+'/coverage_data'):
-        safe_rmtree(args.out_dir_plots+'/coverage_data')
-        os.mkdir(args.out_dir_plots+'/coverage_data')
-    else:
+    if not os.path.exists(args.out_dir_plots+'/coverage_data'):
         os.mkdir(args.out_dir_plots+'/coverage_data')
 
     thread_pool = Pool(args.threads)

--- a/src/main.py
+++ b/src/main.py
@@ -553,8 +553,7 @@ def cna_process(args):
             #csv_df_phasesets = csv_df_chromosomes_sorter(args.quick_start_coverage_path + '/coverage_ps.csv', ['chr', 'start', 'end', 'coverage'])
         elif args.histogram_coverage:
             if os.path.exists(args.out_dir_plots + '/coverage_data'):
-                safe_rmtree(args.out_dir_plots + '/coverage_data')
-                os.mkdir(args.out_dir_plots + '/coverage_data')
+                pass  # keep existing coverage data for quick-start
             else:
                 os.mkdir(args.out_dir_plots + '/coverage_data')
             logger.info('Computing coverage for bins')


### PR DESCRIPTION
Wakhan's breakpoint parser assumed Severus-specific VCF conventions, so VCFs from other callers were silently dropped or crashed the parser.

Changes:
- Read the variant-supporting read count (DV) by looking up its position in each record's own FORMAT column instead of a fixed index. This also corrects Severus, whose DV is at index 5 (index 4 is DR, the reference read count). Callers with no DV field are passed through on their own FILTER rather than being assigned a low default and filtered out.
- Determine SV type from the SVTYPE INFO field rather than substring matching on the variant ID, which only worked for Severus-style IDs.
- Use abs(SVLEN) in length filters, since most callers write deletion lengths as negative values.
- Parse BND mate coordinates by splitting on the bracket rather than stripping '[', ']' and 'N'. Severus writes 'N' as the ref base placeholder; other callers write the real base, which was left glued to the chromosome name (e.g. 'Gchr5') and caused the record to be discarded.
- Preserve an existing coverage_data directory instead of deleting and recreating it, so --quick-start input files survive the run.

Validated against Severus, Sniffles2, Savana, NanoMonSV and the GIAB HG008-T draft benchmark VCF. All variant counts reaching the plot are accounted for by the existing INS-skip and breakpoints-min-length rules.


Note for review: the DV fix changes existing Severus behaviour — Wakhan was reading FORMAT index 4 (DR, reference reads) rather than index 5 (DV, variant reads), so Severus breakpoint sets will shift slightly. Also, callers that don't report DV (Savana, NanoMonSV, benchmark) now pass through on their own FILTER instead of Wakhan's coverage threshold.